### PR TITLE
Implement better error handling with specific exception types

### DIFF
--- a/AutoRip2MKV/AutoRip2MKV.csproj
+++ b/AutoRip2MKV/AutoRip2MKV.csproj
@@ -121,6 +121,7 @@
     <Compile Include="ConfigurationManager.cs" />
     <Compile Include="ICredentialManager.cs" />
     <Compile Include="WindowsCredentialManager.cs" />
+    <Compile Include="CustomExceptions.cs" />
     <Compile Include="ServiceContainer.cs" />
     <Compile Include="OpenOrCloseCDDrive.cs" />
     <Compile Include="Preferences.cs">

--- a/AutoRip2MKV/CustomExceptions.cs
+++ b/AutoRip2MKV/CustomExceptions.cs
@@ -1,0 +1,147 @@
+using System;
+
+namespace AutoRip2MKV
+{
+    /// <summary>
+    /// Base exception for all AutoRip2MKV specific exceptions
+    /// </summary>
+    public abstract class AutoRip2MKVException : Exception
+    {
+        protected AutoRip2MKVException() { }
+        protected AutoRip2MKVException(string message) : base(message) { }
+        protected AutoRip2MKVException(string message, Exception innerException) : base(message, innerException) { }
+    }
+
+    /// <summary>
+    /// Thrown when configuration validation fails
+    /// </summary>
+    public class ConfigurationException : AutoRip2MKVException
+    {
+        public ConfigurationException() { }
+        public ConfigurationException(string message) : base(message) { }
+        public ConfigurationException(string message, Exception innerException) : base(message, innerException) { }
+    }
+
+    /// <summary>
+    /// Thrown when MakeMKV operations fail
+    /// </summary>
+    public class MakeMKVException : AutoRip2MKVException
+    {
+        public int ExitCode { get; }
+
+        public MakeMKVException() { }
+        public MakeMKVException(string message) : base(message) { }
+        public MakeMKVException(string message, Exception innerException) : base(message, innerException) { }
+        public MakeMKVException(string message, int exitCode) : base(message)
+        {
+            ExitCode = exitCode;
+        }
+        public MakeMKVException(string message, int exitCode, Exception innerException) : base(message, innerException)
+        {
+            ExitCode = exitCode;
+        }
+    }
+
+    /// <summary>
+    /// Thrown when HandBrake operations fail
+    /// </summary>
+    public class HandBrakeException : AutoRip2MKVException
+    {
+        public int ExitCode { get; }
+
+        public HandBrakeException() { }
+        public HandBrakeException(string message) : base(message) { }
+        public HandBrakeException(string message, Exception innerException) : base(message, innerException) { }
+        public HandBrakeException(string message, int exitCode) : base(message)
+        {
+            ExitCode = exitCode;
+        }
+        public HandBrakeException(string message, int exitCode, Exception innerException) : base(message, innerException)
+        {
+            ExitCode = exitCode;
+        }
+    }
+
+    /// <summary>
+    /// Thrown when disc operations fail
+    /// </summary>
+    public class DiscException : AutoRip2MKVException
+    {
+        public string DriveLetter { get; }
+
+        public DiscException() { }
+        public DiscException(string message) : base(message) { }
+        public DiscException(string message, Exception innerException) : base(message, innerException) { }
+        public DiscException(string message, string driveLetter) : base(message)
+        {
+            DriveLetter = driveLetter;
+        }
+        public DiscException(string message, string driveLetter, Exception innerException) : base(message, innerException)
+        {
+            DriveLetter = driveLetter;
+        }
+    }
+
+    /// <summary>
+    /// Thrown when credential operations fail
+    /// </summary>
+    public class CredentialException : AutoRip2MKVException
+    {
+        public string CredentialKey { get; }
+
+        public CredentialException() { }
+        public CredentialException(string message) : base(message) { }
+        public CredentialException(string message, Exception innerException) : base(message, innerException) { }
+        public CredentialException(string message, string credentialKey) : base(message)
+        {
+            CredentialKey = credentialKey;
+        }
+        public CredentialException(string message, string credentialKey, Exception innerException) : base(message, innerException)
+        {
+            CredentialKey = credentialKey;
+        }
+    }
+
+    /// <summary>
+    /// Thrown when email/notification operations fail
+    /// </summary>
+    public class NotificationException : AutoRip2MKVException
+    {
+        public string NotificationType { get; }
+
+        public NotificationException() { }
+        public NotificationException(string message) : base(message) { }
+        public NotificationException(string message, Exception innerException) : base(message, innerException) { }
+        public NotificationException(string message, string notificationType) : base(message)
+        {
+            NotificationType = notificationType;
+        }
+        public NotificationException(string message, string notificationType, Exception innerException) : base(message, innerException)
+        {
+            NotificationType = notificationType;
+        }
+    }
+
+    /// <summary>
+    /// Thrown when file operations fail
+    /// </summary>
+    public class FileOperationException : AutoRip2MKVException
+    {
+        public string FilePath { get; }
+        public string Operation { get; }
+
+        public FileOperationException() { }
+        public FileOperationException(string message) : base(message) { }
+        public FileOperationException(string message, Exception innerException) : base(message, innerException) { }
+        public FileOperationException(string message, string operation, string filePath) : base(message)
+        {
+            Operation = operation;
+            FilePath = filePath;
+        }
+        public FileOperationException(string message, string operation, string filePath, Exception innerException) : base(message, innerException)
+        {
+            Operation = operation;
+            FilePath = filePath;
+        }
+    }
+}

--- a/AutoRip2MKV/Ripping.cs
+++ b/AutoRip2MKV/Ripping.cs
@@ -41,11 +41,15 @@ namespace AutoRip2MKV
                         var credentialManager = ServiceContainer.Instance.Resolve<ICredentialManager>();
                         credentialManager.MigrateFromPlainText();
                     }
+                    catch (InvalidOperationException ex)
+                    {
+                        Logger.Error(ex, "Operation failed during credential migration");
+                    }
                     catch (Exception ex)
                     {
-                        Logger.Error(ex, "Failed to migrate credentials during startup");
+                        Logger.Error(ex, "Unexpected error during credential migration");
                     }
-                    
+
                     var DVDDriveToUse = GetDriveInfo("drive");
                     var CurrentTitle = GetDriveInfo("label");
 
@@ -64,6 +68,16 @@ namespace AutoRip2MKV
                     Logger.Warn("Another instance is already running.");
                 }
                 Logger.LogOperationComplete("Main", TimeSpan.Zero); // Replace with actual timing logic if needed
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Logger.Fatal(ex, "Unauthorized access");
+                UpdateStatusText("Application needs proper permissions to run");
+            }
+            catch (IOException ex)
+            {
+                Logger.Fatal(ex, "I/O error occurred");
+                UpdateStatusText("An I/O error occurred");
             }
             catch (Exception ex)
             {

--- a/AutoRip2MKV/WindowsCredentialManager.cs
+++ b/AutoRip2MKV/WindowsCredentialManager.cs
@@ -50,7 +50,7 @@ namespace AutoRip2MKV
                     if (!CredWrite(ref credential, 0))
                     {
                         var error = Marshal.GetLastWin32Error();
-                        throw new Win32Exception(error, $"Failed to store credential: {error}");
+                        throw new CredentialException($"Failed to store credential for key '{key}': Win32 Error {error}", key, new Win32Exception(error));
                     }
 
                     Marshal.FreeHGlobal(credential.CredentialBlob);


### PR DESCRIPTION
- Created custom exception hierarchy with AutoRip2MKVException base class
- Added specific exceptions for Configuration, MakeMKV, HandBrake, Disc, Credential, Notification, and FileOperation errors
- Enhanced error handling in Ripping.cs with specific exception catching
- Updated WindowsCredentialManager to use CredentialException for better error context
- Improved error categorization and logging for better debugging
- Each exception type includes relevant context properties (exit codes, file paths, etc.)